### PR TITLE
PLANET-4603 Prepare for new theme attribute name

### DIFF
--- a/assets/src/styles/components/FormField.scss
+++ b/assets/src/styles/components/FormField.scss
@@ -1,3 +1,3 @@
 .hide-donate-toggle-field > .components-base-control__field {
-  margin-bottom: 0px !important;
+  margin-bottom: 0 !important;
 }

--- a/classes/blocks/class-enform.php
+++ b/classes/blocks/class-enform.php
@@ -276,7 +276,10 @@ class ENForm extends Base_Block {
 
 		if ( 'campaign' === get_post_type() ) {
 			$page_meta_data    = get_post_meta( $post->ID );
-			$campaign_template = ! empty( $page_meta_data['_campaign_page_template'][0] ) ? $page_meta_data['_campaign_page_template'][0] : false;
+			$campaign_template = $page_meta_data['theme']
+				?? ! empty( $page_meta_data['_campaign_page_template'][0] )
+					? $page_meta_data['_campaign_page_template'][0]
+					: false;
 			$campaign_data     = [
 				'template' => $campaign_template,
 			];


### PR DESCRIPTION
This was renamed in master-theme from `_campaign_page_template` because
the underscore prevents usage of the field through the REST API. The
name theme is chosen already because we'll be renaming "campaign
templates" to themes later, and also has the benefit of being more
different than just an underscore.