### PR TITLE
PLANET-4746: Campaigns CSS: EN form background overlay

### DIFF
--- a/assets/src/styles/blocks/ENForm/campaigns/themes/_theme_climate.scss
+++ b/assets/src/styles/blocks/ENForm/campaigns/themes/_theme_climate.scss
@@ -1,23 +1,11 @@
 body.theme-climate {
   $jost: "Jost", sans-serif;
-  $gradient-color: red;
   $form-caption-transform: uppercase;
 
   .enform-wrap {
     @include campaign-en-block($jost, $jost, $form-caption-transform);
 
     &.enform-side-style {
-      &::after {
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        z-index: 1;
-        background: $gradient-color;
-        background: linear-gradient(135deg, rgba($gradient-color, 1) 0%, rgba($gradient-color, 0) 100%);
-      }
-
       .form-caption {
         padding-top: 33px;
 


### PR DESCRIPTION
This removes the hard-coded gradient background in the Climate Emergency theme.

Ref: https://jira.greenpeace.org/browse/PLANET-4746