### PR TITLE
PLANET-4335 EN Form: Country field label appears twice on front-end

### DIFF
--- a/templates/blocks/country_select.twig
+++ b/templates/blocks/country_select.twig
@@ -5,7 +5,12 @@
 			class="en__field__input en__field__input--select en_select_country form-control"
 			data-errormessage="{{ errorMessage }}"
 			{{ 'true' == field.required ? 'required' : '' }}>
-			<option value="" selected="selected">- {{ __( 'Select Country or Region', 'planet4-engagingnetworks-backend' ) }} -</option>
+			{% if en_form_style == 'side-style' %}
+				{% set country_default_text = "" %}
+			{% else %}
+				{% set country_default_text = '- '~__( 'Select Country or Region', 'planet4-engagingnetworks-backend' )~' -' %}
+			{% endif %}
+			<option value="" selected="selected">{{ country_default_text }}</option>
 			<option value="AF">Afghanistan</option>
 			<option value="AX">Åland Islands</option>
 			<option value="AL">Albania</option>


### PR DESCRIPTION
- Set the default option on the country select to blank if it is the side style

Ref: https://jira.greenpeace.org/browse/PLANET-4335