### PR TITLE
PLANET-4323 EN form block: fix checkbox styling of form on a side style

### DIFF
--- a/assets/src/styles/blocks/ENForm/components/_enform-side-style.scss
+++ b/assets/src/styles/blocks/ENForm/components/_enform-side-style.scss
@@ -103,6 +103,12 @@
       label {
         margin-bottom: 0;
       }
+
+      p {
+        html[dir="rtl"] & {
+          display: inline;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Small styling fix to make sure that the checkbox label appears next to the checkbox as opposed to below.