### PR TITLE
PLANET-5285 Push default value for gGoal

### DIFF
--- a/templates/blocks/enblock.twig
+++ b/templates/blocks/enblock.twig
@@ -46,7 +46,7 @@
 									<input type="hidden" name="en_page_id" value="{{ fields.en_page_id }}">
 									<input type="hidden" name="thankyou_title" value="{{ fields.thankyou_title }}">
 									<input type="hidden" name="thankyou_subtitle" value="{{ fields.thankyou_subtitle }}">
-									<input type="hidden" name="enform_goal" id="enform_goal" value="{{ fields.enform_goal }}">
+									<input type="hidden" name="enform_goal" id="enform_goal" value="{{ fields.enform_goal|default('not set') }}">
 
 
 									{{ error_msg }}

--- a/templates/blocks/enform.twig
+++ b/templates/blocks/enform.twig
@@ -46,7 +46,7 @@
 									<input type="hidden" name="en_page_id" value="{{ fields.en_page_id }}">
 									<input type="hidden" name="thankyou_title" value="{{ fields.thankyou_title }}">
 									<input type="hidden" name="thankyou_subtitle" value="{{ fields.thankyou_subtitle }}">
-									<input type="hidden" name="enform_goal" id="enform_goal" value="{{ fields.enform_goal }}">
+									<input type="hidden" name="enform_goal" id="enform_goal" value="{{ fields.enform_goal|default('not set') }}">
 
 
 									{{ error_msg }}


### PR DESCRIPTION
* The UI shows the first element on the list for gGoal in the block
editor, however if no manual change was made the attribute would never
be set on the block, which caused it to fire an event without the
gGoal parameter, which in turn caused the event to not be recorded.
Ref: https://jira.greenpeace.org/browse/PLANET-5285
